### PR TITLE
import DynamicScale directly instead of through optim

### DIFF
--- a/training/few_shot_gan_adaption/training.py
+++ b/training/few_shot_gan_adaption/training.py
@@ -3,6 +3,7 @@ import tensorflow_datasets as tfds
 import jax
 import jax.numpy as jnp
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 from flax.core import frozen_dict
 import optax
 import numpy as np
@@ -51,10 +52,10 @@ def train_and_evaluate(config):
 
     platform = jax.local_devices()[0].platform
     if config.mixed_precision and platform == 'gpu':
-        dynamic_scale_G_main = flax.optim.DynamicScale()
-        dynamic_scale_D_main = flax.optim.DynamicScale()
-        dynamic_scale_G_reg = flax.optim.DynamicScale()
-        dynamic_scale_D_reg = flax.optim.DynamicScale()
+        dynamic_scale_G_main = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_D_main = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_G_reg = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_D_reg = dynamic_scale_lib.DynamicScale()
         clip_conv = 256
         num_fp16_res = 4
     else:

--- a/training/few_shot_gan_adaption/training_utils.py
+++ b/training/few_shot_gan_adaption/training_utils.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 from jaxlib.xla_extension import DeviceArray
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 from flax.core import frozen_dict
 from flax.training import train_state
 from flax import struct
@@ -152,7 +153,7 @@ class TrainStateG(train_state.TrainState):
     Attributes:
         apply_mapping (Callable): Apply function of the Mapping Network.
         apply_synthesis (Callable): Apply function of the Synthesis Network.
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
         moving_stats (Any): Moving average of the latent W. 
         noise_consts (Any): Noise constants from synthesis layers.
@@ -160,8 +161,8 @@ class TrainStateG(train_state.TrainState):
     """
     apply_mapping: Callable = struct.field(pytree_node=False)
     apply_synthesis: Callable = struct.field(pytree_node=False)
-    dynamic_scale_main: flax.optim.DynamicScale
-    dynamic_scale_reg: flax.optim.DynamicScale
+    dynamic_scale_main: dynamic_scale_lib.DynamicScale
+    dynamic_scale_reg: dynamic_scale_lib.DynamicScale
     epoch: int
     moving_stats: Any=None
     noise_consts: Any=None
@@ -173,11 +174,11 @@ class TrainStateD(train_state.TrainState):
     Discriminator train state for a single Optax optimizer.
 
     Attributes:
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
     """
-    dynamic_scale_main: flax.optim.DynamicScale
-    dynamic_scale_reg: flax.optim.DynamicScale
+    dynamic_scale_main: dynamic_scale_lib.DynamicScale
+    dynamic_scale_reg: dynamic_scale_lib.DynamicScale
     epoch: int
 
 

--- a/training/resnet/training.py
+++ b/training/resnet/training.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 from jax.lib import xla_bridge
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 import flax.linen as nn
 from flax.training import train_state
 from flax.training import common_utils
@@ -60,11 +61,11 @@ class TrainState(train_state.TrainState):
     Attributes:
         batch_stats (Any): Collection used to store an exponential moving
                            average of the batch statistics.
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
     """
     batch_stats: Any
-    dynamic_scale: flax.optim.DynamicScale
+    dynamic_scale: dynamic_scale_lib.DynamicScale
     epoch: int
 
 
@@ -222,7 +223,7 @@ def train_and_evaluate(config):
 
     platform = jax.local_devices()[0].platform
     if config.mixed_precision and platform == 'gpu':
-        dynamic_scale = flax.optim.DynamicScale()
+        dynamic_scale = dynamic_scale_lib.DynamicScale()
     else:
         dynamic_scale = None
 

--- a/training/stylegan2/README.md
+++ b/training/stylegan2/README.md
@@ -142,7 +142,7 @@ You can disable the FID score evaluation using `--disable_fid`. In that case, a 
 ### Mixed Precision
 Mixed precision training is implemented and can be activated using `--mixed_precision`. However, at the moment it is not stable so I don't recommend using it until further notice.  
 I have implemented all the mixed precision tricks from the original StyleGAN2 implementation (casting to float32 for some operations, using pre-normalization in the modulated conv layer, only using float16 for the higher resolutions, clipping the output of the convolution layers, etc).  
-Dynamic loss scaling is also implemented with [flax.optim.DynamicScale](https://flax.readthedocs.io/en/latest/_autosummary/flax.optim.DynamicScale.html).  
+Dynamic loss scaling is also implemented with [dynamic_scale_lib.DynamicScale](https://flax.readthedocs.io/en/latest/_autosummary/dynamic_scale_lib.DynamicScale.html).  
 I will look into it. If you figure it out, you are more than welcome to submit a PR.
 
 ## Checkpoints

--- a/training/stylegan2/training.py
+++ b/training/stylegan2/training.py
@@ -3,6 +3,7 @@ import tensorflow_datasets as tfds
 import jax
 import jax.numpy as jnp
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 from flax.core import frozen_dict
 import optax
 import numpy as np
@@ -47,10 +48,10 @@ def train_and_evaluate(config):
 
     platform = jax.local_devices()[0].platform
     if config.mixed_precision and platform == 'gpu':
-        dynamic_scale_G_main = flax.optim.DynamicScale()
-        dynamic_scale_D_main = flax.optim.DynamicScale()
-        dynamic_scale_G_reg = flax.optim.DynamicScale()
-        dynamic_scale_D_reg = flax.optim.DynamicScale()
+        dynamic_scale_G_main = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_D_main = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_G_reg = dynamic_scale_lib.DynamicScale()
+        dynamic_scale_D_reg = dynamic_scale_lib.DynamicScale()
         clip_conv = 256
         num_fp16_res = 4
     else:

--- a/training/stylegan2/training_utils.py
+++ b/training/stylegan2/training_utils.py
@@ -2,6 +2,7 @@ import jax
 import jax.numpy as jnp
 from jaxlib.xla_extension import DeviceArray
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 from flax.core import frozen_dict
 from flax.training import train_state
 from flax import struct
@@ -71,15 +72,15 @@ class TrainStateG(train_state.TrainState):
     Attributes:
         apply_mapping (Callable): Apply function of the Mapping Network.
         apply_synthesis (Callable): Apply function of the Synthesis Network.
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
         moving_stats (Any): Moving average of the latent W. 
         noise_consts (Any): Noise constants from synthesis layers.
     """
     apply_mapping: Callable = struct.field(pytree_node=False)
     apply_synthesis: Callable = struct.field(pytree_node=False)
-    dynamic_scale_main: flax.optim.DynamicScale
-    dynamic_scale_reg: flax.optim.DynamicScale
+    dynamic_scale_main: dynamic_scale_lib.DynamicScale
+    dynamic_scale_reg: dynamic_scale_lib.DynamicScale
     epoch: int
     moving_stats: Any=None
     noise_consts: Any=None
@@ -90,11 +91,11 @@ class TrainStateD(train_state.TrainState):
     Discriminator train state for a single Optax optimizer.
 
     Attributes:
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
     """
-    dynamic_scale_main: flax.optim.DynamicScale
-    dynamic_scale_reg: flax.optim.DynamicScale
+    dynamic_scale_main: dynamic_scale_lib.DynamicScale
+    dynamic_scale_reg: dynamic_scale_lib.DynamicScale
     epoch: int
 
 

--- a/training/vgg/training.py
+++ b/training/vgg/training.py
@@ -4,6 +4,7 @@ import jax
 import jax.numpy as jnp
 from jax.lib import xla_bridge
 import flax
+from flax.optim import dynamic_scale as dynamic_scale_lib
 import flax.linen as nn
 from flax.training import train_state
 from flax.training import common_utils
@@ -60,11 +61,11 @@ class TrainState(train_state.TrainState):
     Attributes:
         batch_stats (Any): Collection used to store an exponential moving
                            average of the batch statistics.
-        dynamic_scale (flax.optim.DynamicScale): Dynamic loss scaling for mixed precision gradients.
+        dynamic_scale (dynamic_scale_lib.DynamicScale): Dynamic loss scaling for mixed precision gradients.
         epoch (int): Current epoch.
     """
     batch_stats: Any
-    dynamic_scale: flax.optim.DynamicScale
+    dynamic_scale: dynamic_scale_lib.DynamicScale
     epoch: int
 
 
@@ -208,7 +209,7 @@ def train_and_evaluate(config):
 
     platform = jax.local_devices()[0].platform
     if config.mixed_precision and platform == 'gpu':
-        dynamic_scale = flax.optim.DynamicScale()
+        dynamic_scale = dynamic_scale_lib.DynamicScale()
     else:
         dynamic_scale = None
 


### PR DESCRIPTION
Recent flax.optim no longer exports DynamicScale. This imports it directly as per new examples.
