### PR TITLE
Remove mutual variables from dataclass to support Python 3.11

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -232,7 +232,7 @@ flaxmodels.stylegan2.SynthesisNetwork(*resolution=1024, num_channels=3, w_dim=51
 * **rng (jax.numpy.ndarray)** - PRNG for initialization.
 
 #### Methods
-apply(*dlatents_in, noise_mode='random', rng=random.PRNGKey(0)*)
+apply(*dlatents_in, noise_mode='random', rng=None)
 
 ##### Parameters
 * **dlatents_in (jax.numpy.ndarray)** - Latent input W, shape [batch, w_dim].
@@ -566,7 +566,7 @@ flaxmodels.few_shot_gan_adaption.SynthesisNetwork(*resolution=1024, num_channels
 * **rng (jax.numpy.ndarray)** - PRNG for initialization.
 
 #### Methods
-apply(*dlatents_in, noise_mode='random', rng=random.PRNGKey(0)*)
+apply(*dlatents_in, noise_mode='random', rng=None*)
 
 ##### Parameters
 * **dlatents_in (jax.numpy.ndarray)** - Latent input W, shape [batch, w_dim].

--- a/flaxmodels/stylegan2/discriminator.py
+++ b/flaxmodels/stylegan2/discriminator.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 import flax.linen as nn
 from typing import Any, Tuple, List, Callable
 import h5py
+from dataclasses import  field
 from . import ops
 from .. import utils
 
@@ -91,7 +92,7 @@ class FromRGBLayer(nn.Module):
     param_dict: h5py.Group=None
     clip_conv: float=None
     dtype: str='float32'
-    rng: Any=random.PRNGKey(0)
+    rng: Any=field(default_factory=lambda : random.PRNGKey(0))
 
     @nn.compact
     def __call__(self, x, y):
@@ -153,7 +154,7 @@ class DiscriminatorLayer(nn.Module):
     lr_multiplier: float=1
     clip_conv: float=None
     dtype: str='float32'
-    rng: Any=random.PRNGKey(0)
+    rng: Any=field(default_factory=lambda : random.PRNGKey(0))
 
     @nn.compact
     def __call__(self, x):
@@ -214,7 +215,7 @@ class DiscriminatorBlock(nn.Module):
     nf: Callable=None
     clip_conv: float=None
     dtype: str='float32'
-    rng: Any=random.PRNGKey(0)
+    rng: Any=field(default_factory=lambda : random.PRNGKey(0))
 
     @nn.compact
     def __call__(self, x):
@@ -318,7 +319,7 @@ class Discriminator(nn.Module):
     ckpt_dir: str=None
     
     dtype: str='float32'
-    rng: Any=random.PRNGKey(0)
+    rng: Any=field(default_factory=lambda : random.PRNGKey(0))
 
     def setup(self):
         self.resolution_ = self.resolution

--- a/flaxmodels/stylegan2/ops.py
+++ b/flaxmodels/stylegan2/ops.py
@@ -7,6 +7,7 @@ import numpy as np
 from functools import partial
 from typing import Any
 import h5py
+from dataclasses import  field
 
 
 #------------------------------------------------------
@@ -248,7 +249,7 @@ class LinearLayer(nn.Module):
     param_dict: h5py.Group=None
     layer_name: str=None
     dtype: str='float32'
-    rng: Any=random.PRNGKey(0)
+    rng: Any=field(default_factory=lambda : random.PRNGKey(0))
 
     @nn.compact
     def __call__(self, x):


### PR DESCRIPTION
Newer versions of Python check if a dataclass is defined with an mutual variable and throws an exception.
This happens with the the default seed for some classes (random.PRNGKey(0)) and also in some function definitions.

I proposed a fix to create the PRNGKey as a local variable instead of the globally one in. 
Except for some test where my gpu run out of memory the tests run fine. 

